### PR TITLE
piper: avoid an ugly traceback

### DIFF
--- a/providers/piper/speech_provider_piper/main.py
+++ b/providers/piper/speech_provider_piper/main.py
@@ -170,7 +170,12 @@ class PiperProvider(dbus.service.Object):
         out_signature="",
     )
     def Synthesize(self, fd, utterance, voice_id, pitch, rate, is_ssml):
-        worker = self._worker_pool.pop(0)
+        if len(self._worker_pool) > 0:
+            worker = self._worker_pool.pop(0)
+        else:
+            worker = PiperSynthWorker(self.voices_dir)
+            worker.connect("done", self._on_done)
+
         worker.synthesize(fd.take(), utterance, voice_id, pitch, rate)
 
     @dbus.service.method(


### PR DESCRIPTION
Occasionally the piper provider will try to pop on an empty work queue. Add simple check to avoid a noisy log.